### PR TITLE
Fix IAM Permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,12 @@ permissions in ``iam``:
                     "ec2:DeregisterImage",
                     "ec2:DescribeImages",
                     "ec2:DescribeInstances",
-                    "ec2:DescribeSnapshots"
+                    "ec2:DescribeSnapshots",
+                    "autoscaling:DescribeAutoScalingGroups",
+                    "autoscaling:DescribeLaunchConfigurations"
                 ],
                 "Resource": [
-                    "arn:aws:ec2:::*"
+                    "*"
                 ]
             }
         ]


### PR DESCRIPTION
The existing permissions on this page did not have the appropriate "autoscaling" actions and was two restrictive in it's resource list (some functions, such as DescribeAutoScalingGroups, require `*` permissions to work).