### PR TITLE
ADD: Support for ASGs that use the new LaunchTemplate functionality

### DIFF
--- a/amicleaner/cli.py
+++ b/amicleaner/cli.py
@@ -50,7 +50,9 @@ class App(object):
 
         if not excluded_amis:
             excluded_amis += f.fetch_unattached_lc()
-            excluded_amis += f.fetch_zeroed_asg()
+            excluded_amis += f.fetch_unattached_lt()
+            excluded_amis += f.fetch_zeroed_asg_lc()
+            excluded_amis += f.fetch_zeroed_asg_lt()
             excluded_amis += f.fetch_instances()
 
         candidates = [v

--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -51,12 +51,41 @@ class Fetcher(object):
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=unused_lcs
         )
+
         amis = [lc.get("ImageId")
                 for lc in resp.get("LaunchConfigurations", [])]
 
+
         return amis
 
-    def fetch_zeroed_asg(self):
+    def fetch_unattached_lt(self):
+
+        """
+        Find AMIs for launch templates unattached
+        to autoscaling groups
+        """
+
+        resp = self.asg.describe_auto_scaling_groups()
+        used_lt = (asg.get("LaunchTemplate", {}).get("LaunchTemplateName")
+                   for asg in resp.get("AutoScalingGroups", []))
+
+        resp = self.ec2.describe_launch_templates()
+        all_lts = (lt.get("LaunchTemplateName", "")
+                   for lt in resp.get("LaunchTemplates", []))
+
+        unused_lts = list(set(all_lts) - set(used_lt))
+
+        amis = []
+        for lt_name in unused_lts:
+            resp = self.ec2.describe_launch_template_versions(
+                LaunchTemplateName=lt_name
+            )
+            amis.append(lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
+                        for lt_latest_version in resp.get("LaunchTemplateVersions", []))
+
+        return amis
+
+    def fetch_zeroed_asg_lc(self):
 
         """
         Find AMIs for autoscaling groups who's desired capacity is set to 0
@@ -65,7 +94,7 @@ class Fetcher(object):
         resp = self.asg.describe_auto_scaling_groups()
         zeroed_lcs = [asg.get("LaunchConfigurationName", "")
                       for asg in resp.get("AutoScalingGroups", [])
-                      if asg.get("DesiredCapacity", 0) == 0]
+                      if asg.get("DesiredCapacity", 0) == 0 and len(asg.get("LaunchConfigurationNames", [])) > 0]
 
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=zeroed_lcs
@@ -73,6 +102,39 @@ class Fetcher(object):
 
         amis = [lc.get("ImageId", "")
                 for lc in resp.get("LaunchConfigurations", [])]
+
+        return amis
+    
+    def fetch_zeroed_asg_lt(self):
+
+        """
+        Find AMIs for autoscaling groups who's desired capacity is set to 0
+        """
+
+        resp = self.asg.describe_auto_scaling_groups()
+        # This does not support multiple versions of the same launch template being used
+        zeroed_lts = [asg.get("LaunchTemplate", {})
+                      for asg in resp.get("AutoScalingGroups", [])
+                      if asg.get("DesiredCapacity", 0) == 0]
+
+        zeroed_lt_names = [lt.get("LaunchTemplateName", "")
+                        for lt in zeroed_lts]
+
+        zeroed_lt_versions = [lt.get("LaunchTemplateVersion", "")
+                        for lt in zeroed_lts]
+
+        resp = self.ec2.describe_launch_templates(
+            LaunchTemplateNames=zeroed_lt_names
+        )
+
+        amis = []
+        for lt_name, lt_version in zip(zeroed_lt_names, zeroed_lt_versions):
+            resp = self.ec2.describe_launch_template_versions(
+                LaunchTemplateName=lt_name
+                # Cannot be empty... Versions=[lt_version] - unsure how to pass param only if present in Python 
+            )
+            amis.append(lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
+                        for lt_latest_version in resp.get("LaunchTemplateVersions", []))
 
         return amis
 


### PR DESCRIPTION
Hey,

I don't really know much Python - but I needed support for LaunchTemplates after we moved to utilise them at my day job.

Sorry if the code is rubbish - I am aware there are a few cases I've missed - I feel this stops it breaking for anyone who uses the new LaunchTemplate feature & supports LaunchTemplates as much as the LaunchConfigurations were initially.

Anyone using multiple versions of the same LaunchTemplate will have to PR themselves.

Thanks