### PR TITLE
Increase boto3 max_attempts to 10 

### DIFF
--- a/amicleaner/core.py
+++ b/amicleaner/core.py
@@ -6,7 +6,11 @@ from __future__ import absolute_import
 from builtins import object
 import boto3
 from botocore.exceptions import ClientError
+from botocore.config import Config
+
+from .resources.config import BOTO3_RETRIES
 from .resources.models import AMI
+
 from datetime import datetime
 
 
@@ -15,7 +19,7 @@ class OrphanSnapshotCleaner(object):
     """ Finds and removes ebs snapshots left orphaned """
 
     def __init__(self, ec2=None):
-        self.ec2 = ec2 or boto3.client('ec2')
+        self.ec2 = ec2 or boto3.client('ec2', config=Config(retries={'max_attempts': BOTO3_RETRIES}))
 
     def get_snapshots_filter(self):
 
@@ -92,7 +96,7 @@ class OrphanSnapshotCleaner(object):
 class AMICleaner(object):
 
     def __init__(self, ec2=None):
-        self.ec2 = ec2 or boto3.client('ec2')
+        self.ec2 = ec2 or boto3.client('ec2', config=Config(retries={'max_attempts': BOTO3_RETRIES}))
 
     @staticmethod
     def get_ami_sorting_key(ami):

--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -4,6 +4,8 @@
 from __future__ import absolute_import
 from builtins import object
 import boto3
+from botocore.config import Config
+from .resources.config import BOTO3_RETRIES
 from .resources.models import AMI
 
 
@@ -15,7 +17,7 @@ class Fetcher(object):
 
         """ Initializes aws sdk clients """
 
-        self.ec2 = ec2 or boto3.client('ec2')
+        self.ec2 = ec2 or boto3.client('ec2', config=Config(retries={'max_attempts': BOTO3_RETRIES}))
         self.asg = autoscaling or boto3.client('autoscaling')
 
     def fetch_available_amis(self):

--- a/amicleaner/resources/config.py
+++ b/amicleaner/resources/config.py
@@ -32,3 +32,5 @@ EXCLUDED_MAPPING_VALUES = []
 # Number of days amis to keep based on creation date and grouping strategy
 # not including the ami currently running by an ec2 instance
 AMI_MIN_DAYS = -1
+
+BOTO3_RETRIES = 10


### PR DESCRIPTION
Increase default boto3 max_attempts from 4 to 10, to have the ability to use exponential backoff when AWS API RequestLimit is reached.

`botocore.exceptions.ClientError: An error occurred (RequestLimitExceeded)`