### PR TITLE
Fix support for Python 2.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,13 +2,18 @@
 History
 =======
 
-0.1.0 (2016-08-22)
-------------------
+unreleased (0.2.3?)
+-------------------
 
-* First release on PyPI.
+* Fix support for Python 2.7+
 
 0.1.1 (2016-08-22)
 ------------------
 
 * Documentation update
 * rst files in pip package
+
+0.1.0 (2016-08-22)
+------------------
+
+* First release on PyPI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ boto
 boto3
 prettytable
 blessings==1.6
+future

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 install_requirements = ['awscli', 'argparse', 'boto',
-                        'boto3', 'prettytable', 'blessings']
+                        'boto3', 'prettytable', 'blessings', 'future']
 
 test_requirements = ['moto', 'pytest', 'pytest-pep8', 'pytest-cov']
 


### PR DESCRIPTION
before

```
✗ amicleaner --help
Traceback (most recent call last):
  File "bin/amicleaner", line 7, in <module>
    from amicleaner.cli import main
  File "envs/x/lib/python2.7/site-packages/amicleaner/cli.py", line 6, in <module>
    from builtins import input
ImportError: No module named builtins
```

after
```
✗ amicleaner --help 
usage: amicleaner [-h] [-v] [--from-ids FROM_IDS [FROM_IDS ...]]
                  [--full-report] [--mapping-key MAPPING_KEY]
                  [--mapping-values MAPPING_VALUES [MAPPING_VALUES ...]]
                  [--excluded-mapping-values EXCLUDED_MAPPING_VALUES [EXCLUDED_MAPPING_VALUES ...]]
                  [--keep-previous KEEP_PREVIOUS] [-f] [--check-orphans]
                  [--ami-min-days AMI_MIN_DAYS]

Clean your AMIs on your AWS account. Your AWS credentials must be sourced

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         Prints version and exits
  --from-ids FROM_IDS [FROM_IDS ...]
                        AMI id(s) you simply want to remove
  --full-report         Prints a full report of what to be cleaned
  --mapping-key MAPPING_KEY
                        How to regroup AMIs : [name|tags]
  --mapping-values MAPPING_VALUES [MAPPING_VALUES ...]
                        List of values for tags or name
  --excluded-mapping-values EXCLUDED_MAPPING_VALUES [EXCLUDED_MAPPING_VALUES ...]
                        List of values to be excluded from tags
  --keep-previous KEEP_PREVIOUS
                        Number of previous AMI to keep excluding those
                        currently being running
  -f, --force-delete    Skip confirmation
  --check-orphans       Check and clean orphaned snapshots
  --ami-min-days AMI_MIN_DAYS
                        Number of days AMI to keep excluding those currently
                        being running
```
