### PR TITLE
added option `--owner-id` 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,12 @@ Exclude amis based on tag values
 
     amicleaner --mapping-key tags --mapping-values role env -excluded-mapping-values prod
 
+Specify the aws account owner of the AMIs
+
+ .. code:: bash
+
+     amicleaner --owner-id 1234567
+
 Skip confirmation, can be useful for automation
 
 .. code:: bash

--- a/amicleaner/cli.py
+++ b/amicleaner/cli.py
@@ -10,7 +10,7 @@ import sys
 from amicleaner import __version__
 from .core import AMICleaner, OrphanSnapshotCleaner
 from .fetch import Fetcher
-from .resources.config import MAPPING_KEY, MAPPING_VALUES, EXCLUDED_MAPPING_VALUES
+from .resources.config import MAPPING_KEY, MAPPING_VALUES, EXCLUDED_MAPPING_VALUES, OWNER_ID
 from .resources.config import TERM
 from .utils import Printer, parse_args
 
@@ -29,6 +29,7 @@ class App(object):
         self.full_report = args.full_report
         self.force_delete = args.force_delete
         self.ami_min_days = args.ami_min_days
+        self.owner_id = args.owner_id or OWNER_ID
 
         self.mapping_strategy = {
             "key": self.mapping_key,
@@ -43,7 +44,7 @@ class App(object):
         AMIs from ec2 instances, launch configurations, autoscaling groups
         and returns unused AMIs.
         """
-        f = Fetcher()
+        f = Fetcher(owner_id=self.owner_id)
 
         available_amis = available_amis or f.fetch_available_amis()
         excluded_amis = excluded_amis or []
@@ -68,7 +69,7 @@ class App(object):
         if not candidates_amis:
             return None
 
-        c = AMICleaner()
+        c = AMICleaner(owner_id=self.owner_id)
 
         mapped_amis = c.map_candidates(
             candidates_amis=candidates_amis,
@@ -119,7 +120,7 @@ class App(object):
 
         """ Find and removes orphan snapshots """
 
-        cleaner = OrphanSnapshotCleaner()
+        cleaner = OrphanSnapshotCleaner(owner_id=self.owner_id)
         snaps = cleaner.fetch()
 
         if not snaps:
@@ -140,6 +141,7 @@ class App(object):
     def print_defaults(self):
 
         print(TERM.bold("\nDefault values : ==>"))
+        print(TERM.green("owner_id : {0}".format(self.owner_id)))
         print(TERM.green("mapping_key : {0}".format(self.mapping_key)))
         print(TERM.green("mapping_values : {0}".format(self.mapping_values)))
         print(TERM.green("excluded_mapping_values : {0}".format(self.excluded_mapping_values)))

--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from builtins import object
 import boto3
 from botocore.config import Config
-from .resources.config import BOTO3_RETRIES
+from .resources.config import BOTO3_RETRIES, OWNER_ID
 from .resources.models import AMI
 
 
@@ -13,12 +13,13 @@ class Fetcher(object):
 
     """ Fetches function for AMI candidates to deletion """
 
-    def __init__(self, ec2=None, autoscaling=None):
+    def __init__(self, ec2=None, autoscaling=None, owner_id=None):
 
         """ Initializes aws sdk clients """
 
         self.ec2 = ec2 or boto3.client('ec2', config=Config(retries={'max_attempts': BOTO3_RETRIES}))
         self.asg = autoscaling or boto3.client('autoscaling')
+        self.owner_id = owner_id or OWNER_ID
 
     def fetch_available_amis(self):
 
@@ -26,7 +27,7 @@ class Fetcher(object):
 
         available_amis = dict()
 
-        my_custom_images = self.ec2.describe_images(Owners=['self'])
+        my_custom_images = self.ec2.describe_images(Owners=[self.owner_id])
         for image_json in my_custom_images.get('Images'):
             ami = AMI.object_with_json(image_json)
             available_amis[ami.id] = ami

--- a/amicleaner/resources/config.py
+++ b/amicleaner/resources/config.py
@@ -29,6 +29,9 @@ MAPPING_VALUES = ["environment", "role"]
 EXCLUDED_MAPPING_VALUES = []
 
 
+OWNER_ID = "self"
+
+
 # Number of days amis to keep based on creation date and grouping strategy
 # not including the ami currently running by an ec2 instance
 AMI_MIN_DAYS = -1

--- a/amicleaner/utils.py
+++ b/amicleaner/utils.py
@@ -8,7 +8,7 @@ import argparse
 
 from prettytable import PrettyTable
 
-from .resources.config import KEEP_PREVIOUS, AMI_MIN_DAYS
+from .resources.config import KEEP_PREVIOUS, AMI_MIN_DAYS, OWNER_ID
 
 
 class Printer(object):
@@ -118,6 +118,12 @@ def parse_args(args):
                         default=AMI_MIN_DAYS,
                         help="Number of days AMI to keep excluding those "
                              "currently being running")
+
+    parser.add_argument("--owner-id",
+                        dest='owner_id',
+                        default=OWNER_ID,
+                        help="Owner of the images to clean: "
+                             "[self|amazon|aws-marketplace|123456]")
 
     parsed_args = parser.parse_args(args)
     if parsed_args.mapping_key and not parsed_args.mapping_values:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,6 +166,7 @@ def test_parse_args_no_args():
     assert parser.mapping_values is None
     assert parser.keep_previous is 4
     assert parser.ami_min_days is -1
+    assert parser.owner_id is "self"
 
 
 def test_parse_args():
@@ -184,6 +185,9 @@ def test_parse_args():
     parser = parse_args(['--ami-min-days', '10', '--full-report'])
     assert parser.ami_min_days == 10
     assert parser.full_report is True
+
+    parser = parse_args(['--owner-id', '123456'])
+    assert parser.owner_id == "123456"
 
 
 def test_print_report():


### PR DESCRIPTION
to specify the AWS account id to which belongs the AMI we are gonna delete

It is useful when trying to make some housekeeping in an account that has amis shared from another account.