### PR TITLE
fixes #91: must install `future` for builtins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ awscli
 argparse
 boto
 boto3
+future
 prettytable
 blessings==1.6

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 install_requirements = ['awscli', 'argparse', 'boto',
-                        'boto3', 'prettytable', 'blessings']
+                        'boto3', 'prettytable', 'blessings', 'future']
 
 test_requirements = ['moto', 'pytest', 'pytest-pep8', 'pytest-cov']
 


### PR DESCRIPTION
without this change, I get this issue until I manually install `future`

```
[ec2-user@operator ~]$ sudo amicleaner --full-report
Traceback (most recent call last):
  File "/usr/local/bin/amicleaner", line 11, in <module>
    load_entry_point('aws-amicleaner==0.2.2', 'console_scripts', 'amicleaner')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 564, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2662, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2316, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2322, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/site-packages/amicleaner/cli.py", line 6, in <module>
    from builtins import input
ImportError: No module named builtins
```