### PR TITLE
fix asg bug

### DIFF
--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -67,7 +67,7 @@ class Fetcher(object):
         resp = self.asg.describe_auto_scaling_groups()
         zeroed_lcs = [asg.get("LaunchConfigurationName", "")
                       for asg in resp.get("AutoScalingGroups", [])
-                      if asg.get("DesiredCapacity", 0) == 0]
+                      if asg.get("DesiredCapacity", 0) == 0 and asg.get("LaunchConfigurationName", None) is not None]
 
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=zeroed_lcs


### PR DESCRIPTION
12:14:42  + AWS_DEFAULT_REGION=eu-central-1 amicleaner --mapping-key tags --mapping-values Application --keep-previous 16 --force-delete --full-report
12:14:44  
12:14:44  Default values : ==>
12:14:44  mapping_key : tags
12:14:44  mapping_values : ['Application']
12:14:44  excluded_mapping_values : []
12:14:44  keep_previous : 16
12:14:44  ami_min_days : -1
12:14:44  
12:14:44  Retrieving AMIs to clean ...
12:14:44  Traceback (most recent call last):
12:14:44    File "/usr/local/bin/amicleaner", line 8, in <module>
12:14:44      sys.exit(main())
12:14:44    File "/usr/local/lib/python3.9/dist-packages/amicleaner/cli.py", line 195, in main
12:14:44      app.run_cli()
12:14:44    File "/usr/local/lib/python3.9/dist-packages/amicleaner/cli.py", line 165, in run_cli
12:14:44      candidates = self.prepare_candidates()
12:14:44    File "/usr/local/lib/python3.9/dist-packages/amicleaner/cli.py", line 66, in prepare_candidates
12:14:44      candidates_amis = candidates_amis or self.fetch_candidates()
12:14:44    File "/usr/local/lib/python3.9/dist-packages/amicleaner/cli.py", line 53, in fetch_candidates
12:14:44      excluded_amis += f.fetch_zeroed_asg()
12:14:44    File "/usr/local/lib/python3.9/dist-packages/amicleaner/fetch.py", line 70, in fetch_zeroed_asg
12:14:44      resp = self.asg.describe_launch_configurations(
12:14:44    File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 514, in _api_call
12:14:44      return self._make_api_call(operation_name, kwargs)
12:14:44    File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 901, in _make_api_call
12:14:44      request_dict = self._convert_to_request_dict(
12:14:44    File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 962, in _convert_to_request_dict
12:14:44      request_dict = self._serializer.serialize_to_request(
12:14:44    File "/usr/local/lib/python3.9/dist-packages/botocore/validate.py", line 381, in serialize_to_request
12:14:44      raise ParamValidationError(report=report.generate_report())
12:14:44  botocore.exceptions.ParamValidationError: Parameter validation failed:
12:14:44  Invalid length for parameter LaunchConfigurationNames[0], value: 0, valid min length: 1
12:14:44  Invalid length for parameter LaunchConfigurationNames[1], value: 0, valid min length: 1
[Pipeline] }
12:14:44  Failed in branch clean_eucentral