### PR TITLE
Fix empty groups, add launch template support and show potential cost savings in the report

### DIFF
--- a/amicleaner/utils.py
+++ b/amicleaner/utils.py
@@ -22,22 +22,27 @@ class Printer(object):
         if not candidates:
             return
 
-        groups_table = PrettyTable(["Group name", "candidates"])
+        groups_table = PrettyTable(["Group name", "candidates", "EBS Storage recovered", "Cost Savings"])
+
+        cost_savings = 0
 
         for group_name, amis in candidates.items():
-            groups_table.add_row([group_name, len(amis)])
             eligible_amis_table = PrettyTable(
-                ["AMI ID", "AMI Name", "Creation Date"]
+                ["AMI ID", "AMI Name", "Creation Date", "Size"]
             )
             for ami in amis:
                 eligible_amis_table.add_row([
                     ami.id,
                     ami.name,
-                    ami.creation_date
+                    ami.creation_date,
+                    ami.block_device_mappings[0].volume_size
                 ])
+                cost_savings = cost_savings + ami.block_device_mappings[0].volume_size
+            groups_table.add_row([group_name, len(amis), cost_savings, f"${cost_savings*.1}/mo"])
+
             if full_report:
                 print(group_name)
-                print(eligible_amis_table.get_string(sortby="AMI Name"), "\n\n")
+                print(eligible_amis_table.get_string(sortby="Creation Date"), "\n\n")
 
         print("\nAMIs to be removed:")
         print(groups_table.get_string(sortby="Group name"))


### PR DESCRIPTION
Let me know your thoughts. The Launch Template addition is a little more chatty in boto3, due to the extra call you must make to get the actual launch template version. The original pull only retrieves $Latest or $Default to the version which is unhelpful as I believe we need the integer value for the version. 

I didn't try to make it `neat` in terms of a fancy one-liner here, because it got more complex than the original Launch Configuration. 

I ran it in my current production and was able to recover ~$1,900/mo in savings. YMMV.


```
AMIs to be removed:
+--------------------+------------+-----------------------+--------------+
|     Group name     | candidates | EBS Storage recovered | Cost Savings |
+--------------------+------------+-----------------------+--------------+
| no-tags (excluded) |    256     |         19419         |  $1941.9/mo  |
+--------------------+------------+-----------------------+--------------+

```